### PR TITLE
Règle CSS non prise en compte dans le changement de page

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -13,7 +13,7 @@ let tab = [Game] // Scoreboard, Settings, More
 
 let init = () => {
     tab.forEach(element => {
-        element.classList.add('hide')
+        element.setAttribute('style', 'display: none;')
     });
 }
 
@@ -38,10 +38,10 @@ let changeTab = (name) => {
 }
 
 let showTab = (dataNav, el) => {
-    actualEl.classList.add('hide')
+    actualEl.setAttribute('style', 'display: none;')
     actualEl = el;
     Navbar.activeNavEl(dataNav)
-    el.classList.remove('hide');
+    actualEl.setAttribute('style', '')
 }
 
 export default{

--- a/sass/style.scss
+++ b/sass/style.scss
@@ -6,10 +6,6 @@ body{
     font-family: 'Poppins', Arial, sans-serif;
 }
 
-.hide{
-    display: none;
-}
-
 @import 'nav';
 // @import 'more';
 


### PR DESCRIPTION
Dans le code CSS, on utilise des ID pour gérer l'affichage de nos différentes pages, par conséquent, la règle CSS `.hide` n'avait pas la priorité pour faire un `display: none`.

J'ai donc changé le code JS, pour intégrer la règle directement dans l'élément sans utiliser une classe CSS.